### PR TITLE
Fix highlighting for raw string literals

### DIFF
--- a/languages/csharp/highlights.scm
+++ b/languages/csharp/highlights.scm
@@ -36,10 +36,12 @@
   (verbatim_string_literal)
   (interpolated_string_text)
   (interpolated_verbatim_string_text)
+  (raw_string_literal)
   "\""
   "$\""
   "@$\""
   "$@\""
+  "\"\"\""
  ] @string
 
 [


### PR DESCRIPTION
Adds the missing highlight definition for raw string literals in `highlights.scm`. 

## Before/After Screenshots
<img width="538" alt="image" src="https://github.com/user-attachments/assets/ee070bf9-fd44-4e7b-ad8a-b93b7da81324" />

<img width="538" alt="image" src="https://github.com/user-attachments/assets/eba36d9e-3d49-4cbb-a309-44df7839fecd" />
