### PR TITLE
Add C# textobjects queries for classes functions and comments

### DIFF
--- a/languages/csharp/textobjects.scm
+++ b/languages/csharp/textobjects.scm
@@ -1,0 +1,18 @@
+;; Join up all the comments
+(comment)+ @comment.around
+
+;; Standard methods
+(method_declaration
+  body: (_ "{" (_)* @function.inside "}")) @function.around
+
+;; Standard classes
+(class_declaration
+  body: (_ "{" (_)* @function.inside "}")) @function.around
+
+;; Interface declarations
+(method_declaration) @function.around
+
+;; Lambda expressions
+(lambda_expression
+  body: (_ "{"? (_)* @function.inside "}"? )
+) @function.around


### PR DESCRIPTION
Support for selection around and inside with the following keybindings

- `vif` Select inside functions
- `vaf` Select around functions
- `vic` Select inside classes
- `vac` Select around classes

This also works with lambdas with one exception. When using the "around function" motion it will use visual line mode. So if the arguments are on the same line as around will select the hole block.

Also adds support for navigations with `[f` has support for methods and interface methods with no body.