### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "zed_csharp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_csharp"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "csharp"
 name = "C#"
 description = "C# support."
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = ["fminkowski <fminkowski@gmail.com>"]
 repository = "https://github.com/zed-extensions/csharp"


### PR DESCRIPTION
This PR bumps the version of the extension to 0.1.3.

Includes: 
- https://github.com/zed-extensions/csharp/pull/5
- https://github.com/zed-extensions/csharp/pull/16
- https://github.com/zed-extensions/csharp/pull/23
- https://github.com/zed-extensions/csharp/pull/24