### PR TITLE
Tweak default configuration to be more performant on Windows

### DIFF
--- a/src/csharp.rs
+++ b/src/csharp.rs
@@ -51,7 +51,8 @@ impl zed::Extension for CsharpExtension {
         worktree: &zed::Worktree,
     ) -> Result<Option<zed::serde_json::Value>> {
         if language_server_id.as_ref() == Roslyn::LANGUAGE_SERVER_ID {
-            return Roslyn::configuration_options(worktree);
+            let roslyn = self.roslyn.get_or_insert_with(Roslyn::new);
+            return roslyn.configuration_options(worktree);
         }
         Ok(None)
     }


### PR DESCRIPTION
Added Roslyn configuration options to be better optimized for large repos. In particular, the `dotnet_analyzer_diagnostics_scope` and the `dotnet_compiler_diagnostics_scope` are set to `OpenFiles`, so they aren't trying to run across the entire project all at once. Added caching for json set in the `transform_settings_for_roslyn` function, which was generating a new json every few seconds to check for changes, causing bloated memory over time.

Disclaimer: I made this PR to solve an issue I'm currently facing. However, I am not completely proficient in Rust, so this was mostly built using GitHub copilot and some well-engineered prompts. I've tested it in Zed (both Preview and Nightly) after a `cargo build --release` and it does seem to solve the issue of Zed hanging after Roslyn has been running too long on Windows. That said, please feel free to make improvements if anything stands out.