### PR TITLE
Remove unneeded capability

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -20,9 +20,3 @@ language = "CSharp"
 [grammars.c_sharp]
 repository = "https://github.com/tree-sitter/tree-sitter-c-sharp"
 commit = "485f0bae0274ac9114797fc10db6f7034e4086e3"
-
-# Used to run `csharp-language-server --download` after an update
-[[capabilities]]
-kind = "process:exec"
-command = "*"
-args = ["--download"]


### PR DESCRIPTION
`csharp-language-server` is not used anymore.