### PR TITLE
Use different NuGet feed for roslyn-language-server

### DIFF
--- a/src/language_servers/nuget.rs
+++ b/src/language_servers/nuget.rs
@@ -2,8 +2,7 @@ use std::cmp::Ordering;
 
 use zed_extension_api::{self as zed, http_client, serde_json, Result};
 
-const ROSLYN_NUGET_FEED_INDEX: &str =
-    "https://api.nuget.org/v3/index.json";
+const ROSLYN_NUGET_FEED_INDEX: &str = "https://api.nuget.org/v3/index.json";
 
 pub struct NuGetClient {
     package_base_address: Option<String>,


### PR DESCRIPTION
It seems like some of the packages in the msft_consumption require authentication. Let's just switch to the NuGet.org feed for now.