### PR TITLE
Add automatic solution detection for Roslyn

### DIFF
--- a/src/language_servers/mod.rs
+++ b/src/language_servers/mod.rs
@@ -1,5 +1,6 @@
 pub mod nuget;
 pub mod omnisharp;
+mod project_detection;
 pub mod roslyn;
 pub mod util;
 

--- a/src/language_servers/project_detection.rs
+++ b/src/language_servers/project_detection.rs
@@ -1,0 +1,42 @@
+use zed_extension_api::{self as zed, settings::LspSettings};
+
+/// Try to find the solution file for the worktree.
+/// Priority: user setting > auto-detect by folder name.
+pub fn resolve_solution(worktree: &zed::Worktree) -> Result<Option<String>, String> {
+    if let Some(configured) = user_configured_solution(worktree) {
+        if worktree.read_text_file(&configured).is_ok() {
+            return Ok(Some(configured));
+        }
+        return Err(format!(
+            "Configured solution '{}' not found. Check your lsp.roslyn.settings.solution setting.",
+            configured
+        ));
+    }
+
+    Ok(auto_detect_solution(worktree))
+}
+
+fn user_configured_solution(worktree: &zed::Worktree) -> Option<String> {
+    let settings = LspSettings::for_worktree("roslyn", worktree).ok()?;
+    let settings_value = settings.settings?;
+    settings_value
+        .get("solution")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn auto_detect_solution(worktree: &zed::Worktree) -> Option<String> {
+    let root = worktree.root_path();
+    let project_name = root
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .or_else(|| root.rsplit('\\').find(|s| !s.is_empty()))
+        .unwrap_or(&root);
+
+    let primary = format!("{project_name}.sln");
+    if worktree.read_text_file(&primary).is_ok() {
+        return Some(primary);
+    }
+
+    None
+}

--- a/src/language_servers/roslyn.rs
+++ b/src/language_servers/roslyn.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
 
-use crate::language_servers::{nuget::NuGetClient, util};
+use crate::language_servers::{nuget::NuGetClient, project_detection, util};
 
 const PACKAGE_PREFIX: &str = "roslyn-language-server";
 const SERVER_BINARY: &str = "Microsoft.CodeAnalysis.LanguageServer";
@@ -153,10 +153,15 @@ impl Roslyn {
             .ok()
             .and_then(|lsp_settings| lsp_settings.settings);
 
-        Ok(settings.map(Self::transform_settings_for_roslyn))
+        let solution_path = project_detection::resolve_solution(worktree).unwrap_or(None);
+
+        Ok(Some(Self::build_configuration(settings, solution_path)))
     }
 
-    fn transform_settings_for_roslyn(settings: zed::serde_json::Value) -> zed::serde_json::Value {
+    fn build_configuration(
+        user_settings: Option<zed::serde_json::Value>,
+        solution_path: Option<String>,
+    ) -> zed::serde_json::Value {
         let mut roslyn_config = zed::serde_json::json!({
             // These code lenses show up as "Unknown Command" in Zed and don't do anything when clicked. Disable them by default.
             "csharp|code_lens.dotnet_enable_references_code_lens": false,
@@ -176,20 +181,24 @@ impl Roslyn {
         });
 
         let config_map = roslyn_config.as_object_mut().unwrap();
-        if let zed::serde_json::Value::Object(settings_map) = settings {
+
+        if let Some(sln) = solution_path {
+            config_map.insert(
+                "dotnet.defaultSolution".to_string(),
+                zed::serde_json::Value::String(sln),
+            );
+        }
+
+        if let Some(zed::serde_json::Value::Object(settings_map)) = user_settings {
             for (key, value) in settings_map {
                 if key.contains('|') {
-                    // This is already in the language|category format
                     if let zed::serde_json::Value::Object(nested_settings) = value {
                         for (nested_key, nested_value) in nested_settings {
-                            // The key already contains the proper format, just add the setting
                             config_map.insert(format!("{key}.{nested_key}"), nested_value);
                         }
                     }
-                }
-                // Handle direct roslyn-format settings (fallback for any other format)
-                else if key.contains('.') {
-                    config_map.insert(key.clone(), value.clone());
+                } else if key.contains('.') {
+                    config_map.insert(key, value);
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR adds automatic `.sln` file detection so Roslyn gets an explicit `dotnet.defaultSolution` hint, rather than relying solely on `--autoLoadProjects` to scan the workspace.

### What it does

1. **Auto-detect** — Looks for `<project_folder_name>.sln` in the workspace root. If found, passes it to Roslyn via `dotnet.defaultSolution` in the workspace configuration.
2. **User override** — Users can explicitly set the solution path in Zed settings:
   ```jsonc
   {
     "lsp": {
       "roslyn": {
         "settings": {
           "solution": "MySolution.sln"
         }
       }
     }
   }
   ```
   This takes priority over auto-detection.
3. **No-op when nothing found** — If no `.sln` is detected and the user hasn't configured one, behavior is unchanged (Roslyn falls back to `--autoLoadProjects`).

### Why

- `--autoLoadProjects` alone can be slow or unpredictable, especially when multiple `.sln` files exist (common in Unity projects).
- With an explicit `dotnet.defaultSolution`, Roslyn loads the correct solution immediately instead of scanning the directory tree.
- This also fixes an issue where `configuration_options` returned `None` when users had no custom settings, meaning the default Code Lens and Inlay Hints configuration was not applied unless users had at least one custom setting.

### Changes

- **New file**: `src/language_servers/project_detection.rs` — solution resolution logic
- **Modified**: `src/language_servers/roslyn.rs` — `configuration_options` now always returns defaults + detected solution
- **Modified**: `src/language_servers/mod.rs` — registers the new module

Made with [Cursor](https://cursor.com)