### PR TITLE
fix(omnisharp): forward shell environment to server process

### DIFF
--- a/src/csharp.rs
+++ b/src/csharp.rs
@@ -33,7 +33,7 @@ impl zed::Extension for CsharpExtension {
                 Ok(zed::Command {
                     command: omnisharp_binary.path,
                     args: omnisharp_binary.args.unwrap_or_else(|| vec!["-lsp".into()]),
-                    env: Default::default(),
+                    env: worktree.shell_env(),
                 })
             }
             Roslyn::LANGUAGE_SERVER_ID => {


### PR DESCRIPTION
## Summary

Make the OmniSharp server inherit the worktree shell environment explicitly, matching the pattern used by the other Zed extensions in this org. The previous `env: Default::default()` relied on Zed core's default behavior of inheriting the parent process env to the spawned subprocess — this PR makes that flow explicit and predictable.

## Why this is worth doing (and what it is not)

This is **not a bug fix** in the strict sense. On Apple Silicon, OmniSharp from this extension fails on a fresh setup with:

```
Failed to load /usr/local/share/dotnet/x64/host/fxr/5.0.17/libhostfxr.dylib,
error: mach-o file, but is an incompatible architecture
(have 'x86_64', need 'arm64e' or 'arm64')
```

The actual fix for the user is to install the arm64 .NET runtime and export `DOTNET_ROOT=/usr/local/share/dotnet` in their shell init — once they do that, OmniSharp already works without this patch, because the value reaches the subprocess via Zed core's default env inheritance.

What this PR changes:

- **Before**: the extension passes `env: Default::default()` (empty). The subprocess still gets Zed's process env by default, so things tend to work, but the contract is implicit.
- **After**: the extension passes `worktree.shell_env()` explicitly. Same effective behavior in the happy path, but the contract is now visible in code and protected against future changes to how Zed core handles `env` from extensions.

## Why this pattern, specifically

`worktree.shell_env()` is exactly what the other extensions in this org already do:

- `zed-extensions/nix` (`src/language_servers/nil.rs`)
- `zed-extensions/ocaml` (`src/ocaml.rs`, three call sites)
- `zed-extensions/pyrefly` (`src/pyrefly.rs`)
- `zed-extensions/ruby` (`src/language_servers/language_server.rs`)

So this is more of a "bring csharp in line with the rest of the org" change than a behavior change.

Scoped to OmniSharp only — Roslyn's `build_command` doesn't receive a `Worktree` and would need a separate small refactor.

## Test plan

- [x] `cargo check` passes
- [x] Installed locally on macOS arm64 with `DOTNET_ROOT` exported in `.zshrc`. OmniSharp starts and reports `Running v1.39.15` in the language server status panel.

## Context

The underlying Apple Silicon footgun has been around since [zed-industries/zed#8352](https://github.com/zed-industries/zed/issues/8352) (2024) and resurfaced as a workaround target for the Roslyn watcher storm in [zed-industries/zed#55746](https://github.com/zed-industries/zed/issues/55746). The shell-side `DOTNET_ROOT` setup is the real user-facing fix and probably belongs in the README — happy to send that as a separate PR.