### PR TITLE
docs(readme): document language servers and Apple Silicon DOTNET_ROOT setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,47 @@
 
 A [C#](https://learn.microsoft.com/en-us/dotnet/csharp/) extension for [Zed](https://zed.dev).
 
+## Language servers
+
+This extension supports two language servers:
+
+- **Roslyn** (default): Microsoft's `Microsoft.CodeAnalysis.LanguageServer`, downloaded from NuGet on first launch.
+- **OmniSharp**: the community-maintained `OmniSharp/omnisharp-roslyn` server, downloaded from GitHub releases on first launch.
+
+To pin a specific server, set `language_servers` in your Zed settings:
+
+```json
+{
+  "languages": {
+    "CSharp": {
+      "language_servers": ["omnisharp", "!roslyn"]
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### OmniSharp fails to start on macOS Apple Silicon
+
+If OmniSharp fails on first launch with an error like:
+
+```
+Failed to load /usr/local/share/dotnet/x64/host/fxr/<version>/libhostfxr.dylib,
+error: mach-o file, but is an incompatible architecture
+(have 'x86_64', need 'arm64e' or 'arm64')
+```
+
+the bundled OmniSharp binary itself is arm64-native, but the .NET host resolver is picking up a legacy x86_64 `libhostfxr.dylib` from `/usr/local/share/dotnet/x64/` (left over from an Intel/Rosetta-era installer).
+
+Fix: install the arm64 .NET runtime and point `DOTNET_ROOT` at it explicitly in your shell init (`~/.zshrc`, `~/.zprofile`, or equivalent):
+
+```sh
+export DOTNET_ROOT="/usr/local/share/dotnet"
+```
+
+Restart Zed so it inherits the variable from the shell, then reopen the C# project.
+
 ## Development
 
 To develop this extension, see the [Developing Extensions](https://zed.dev/docs/extensions/developing-extensions) section of the Zed docs.


### PR DESCRIPTION
## Summary

The README is minimal and doesn't surface two things that come up repeatedly in issues:

1. The extension ships **two** language servers (Roslyn and OmniSharp) and you can pick which one via `language_servers` in Zed settings.
2. On macOS Apple Silicon, OmniSharp can fail on a fresh install because the .NET host resolver picks up a legacy x86_64 `libhostfxr.dylib` from `/usr/local/share/dotnet/x64/` instead of the arm64 runtime.

This PR adds:

- A short **Language servers** section with the `language_servers` pin example.
- A **Troubleshooting** entry for the Apple Silicon `libhostfxr` arch mismatch, pointing users to set `DOTNET_ROOT` in their shell init.

## Why this matters

The arm64 footgun has been around since [zed-industries/zed#8352](https://github.com/zed-industries/zed/issues/8352) (2024). Pinning to OmniSharp is also the workaround currently being recommended in [zed-industries/zed#55746](https://github.com/zed-industries/zed/issues/55746) for the Roslyn watcher storm, and several users have reported confusion landing on it without realizing `DOTNET_ROOT` is required on Apple Silicon.

Docs-only. No code changes.