### PR TITLE
Use absolute paths for dotnet launched DLLs

### DIFF
--- a/src/language_servers/csharp_ls.rs
+++ b/src/language_servers/csharp_ls.rs
@@ -120,7 +120,7 @@ impl CsharpLs {
         let dll_path = format!("{tools_dir}/{tfm}/any/{SERVER_DLL}");
 
         if fs::metadata(&dll_path).is_ok_and(|s| s.is_file()) {
-            Ok(dll_path)
+            util::absolute_path(&dll_path)
         } else {
             Err(format!(
                 "csharp-ls package layout unexpected: missing entry DLL at '{dll_path}'"

--- a/src/language_servers/roslyn.rs
+++ b/src/language_servers/roslyn.rs
@@ -133,7 +133,10 @@ impl Roslyn {
             .ok_or_else(|| format!("no TFM directory found inside '{tools_dir}'"))?;
 
         let server_dir = format!("{tools_dir}/{tfm}/{rid}");
-        Ok(Self::server_path_for_rid(rid, server_dir))
+        match Self::server_path_for_rid(rid, server_dir) {
+            ServerPath::Dll(path) => Ok(ServerPath::Dll(util::absolute_path(&path)?)),
+            exe => Ok(exe),
+        }
     }
 
     fn server_path_for_rid(rid: &str, server_dir: String) -> ServerPath {

--- a/src/language_servers/util.rs
+++ b/src/language_servers/util.rs
@@ -2,6 +2,12 @@ use std::fs;
 
 use zed_extension_api::Result;
 
+pub(super) fn absolute_path(path: &str) -> Result<String> {
+    let cwd = std::env::current_dir()
+        .map_err(|e| format!("failed to resolve extension working directory: {e}"))?;
+    Ok(cwd.join(path).to_string_lossy().into_owned())
+}
+
 pub(super) fn remove_outdated_versions(
     language_server_id: &'static str,
     version_dir: &str,


### PR DESCRIPTION
resolves #88 

Zed spawns dotnet with its  working directory set to the worktree root.
We must use absolute paths to reference the cs-language server, so the extension installed one can be found.