### PR TITLE
Add semantic token rules for Roslyn token types

### DIFF
--- a/languages/csharp/semantic_token_rules.json
+++ b/languages/csharp/semantic_token_rules.json
@@ -1,0 +1,16 @@
+[
+  { "token_type": "field", "style": ["property", "variable.member", "variable"] },
+  { "token_type": "constant", "style": ["constant"] },
+  { "token_type": "controlKeyword", "style": ["keyword.control", "keyword"] },
+  { "token_type": "delegate", "style": ["type.delegate", "type"] },
+  { "token_type": "extensionMethod", "style": ["function.method", "function"] },
+  { "token_type": "operatorOverloaded", "style": ["operator"] },
+  { "token_type": "recordClass", "style": ["type.class", "class", "type"] },
+  { "token_type": "recordStruct", "style": ["type.struct", "struct", "type"] },
+  { "token_type": "module", "style": ["namespace", "module"] },
+  { "token_type": "functionPointer", "style": ["function", "type"] },
+  { "token_type": "pointer", "style": ["type"] },
+  { "token_type": "excludedCode", "style": ["comment"] },
+  { "token_type": "stringVerbatim", "style": ["string"] },
+  { "token_type": "stringEscapeCharacter", "style": ["string.escape", "string.special", "string"] }
+]


### PR DESCRIPTION
Roslyn reports an extended semantic-token legend (`field`, `controlKeyword`, `recordClass`, `extensionMethod`, ...) beyond the standard LSP types. Without rules for them, those tokens are dropped and C# falls back to tree-sitter-only highlighting (e.g. a private field looks like a local variable).

This adds `languages/csharp/semantic_token_rules.json` mapping the C#-specific types to theme styles. Standard types stay covered by Zed's built-in defaults, so only the Roslyn-specific ones are listed here (same approach the built-in rust/cpp/go/python rules use).

Fixes #85. Moved here from zed-industries/zed#60027 per @MrSubidubi's suggestion. Needs zed-industries/zed#60015 (dynamic registration of `textDocument/semanticTokens`) to actually deliver the tokens — together they resolve #85.

## Showcase

<details>
  <summary>Click to view showcase</summary>

**Before** — Roslyn's C# token types aren't mapped, so fields/keywords fall back to tree-sitter (a field looks like a plain variable):

<img width="979" height="1089" alt="Screenshot 2026-06-28 at 10 06 41" src="https://github.com/user-attachments/assets/26a79bc9-f7c6-4700-8b39-0505af75180c" />

**After** — fields, constants, control-flow keywords and records get semantic colors:

<img width="934" height="1032" alt="Screenshot 2026-06-28 at 09 58 15" src="https://github.com/user-attachments/assets/def44b05-85fa-4b39-9ea7-74ceb667bf6d" />

</details>