### PR TITLE
add msbuild language server

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -21,6 +21,15 @@ language = "CSharp"
 name = "csharp-ls"
 language = "CSharp"
 
+[language_servers.msbuild-project-tools]
+name = "MSBuild Project Tools"
+language = ["C# Project File", "MSBuild File", "C# Solution File"]
+
+[language_servers.msbuild-project-tools.language_ids]
+"C# Project File" = "xml"
+"MSBuild File" = "xml"
+"C# Solution File" = "xml"
+
 [grammars.c_sharp]
 repository = "https://github.com/tree-sitter/tree-sitter-c-sharp"
 commit = "485f0bae0274ac9114797fc10db6f7034e4086e3"

--- a/src/csharp.rs
+++ b/src/csharp.rs
@@ -2,12 +2,13 @@ mod language_servers;
 
 use zed_extension_api::{self as zed, Result};
 
-use crate::language_servers::{CsharpLs, Omnisharp, Roslyn};
+use crate::language_servers::{CsharpLs, MsbuildProjectTools, Omnisharp, Roslyn};
 
 struct CsharpExtension {
     omnisharp: Option<Omnisharp>,
     roslyn: Option<Roslyn>,
     csharp_ls: Option<CsharpLs>,
+    msbuild_project_tools: Option<MsbuildProjectTools>,
 }
 
 impl CsharpExtension {}
@@ -18,6 +19,7 @@ impl zed::Extension for CsharpExtension {
             omnisharp: None,
             roslyn: None,
             csharp_ls: None,
+            msbuild_project_tools: None,
         }
     }
 
@@ -46,6 +48,12 @@ impl zed::Extension for CsharpExtension {
                 let csharp_ls = self.csharp_ls.get_or_insert_with(CsharpLs::new);
                 csharp_ls.language_server_cmd(language_server_id, worktree)
             }
+            MsbuildProjectTools::LANGUAGE_SERVER_ID => {
+                let msbuild_project_tools = self
+                    .msbuild_project_tools
+                    .get_or_insert_with(MsbuildProjectTools::new);
+                msbuild_project_tools.language_server_cmd(language_server_id, worktree)
+            }
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }
     }
@@ -58,6 +66,22 @@ impl zed::Extension for CsharpExtension {
         match language_server_id.as_ref() {
             Roslyn::LANGUAGE_SERVER_ID => Roslyn::configuration_options(worktree),
             CsharpLs::LANGUAGE_SERVER_ID => CsharpLs::configuration_options(worktree),
+            MsbuildProjectTools::LANGUAGE_SERVER_ID => {
+                MsbuildProjectTools::configuration_options(worktree)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        match language_server_id.as_ref() {
+            MsbuildProjectTools::LANGUAGE_SERVER_ID => {
+                MsbuildProjectTools::initialization_options(worktree)
+            }
             _ => Ok(None),
         }
     }

--- a/src/language_servers/mod.rs
+++ b/src/language_servers/mod.rs
@@ -1,9 +1,11 @@
 pub mod csharp_ls;
+pub mod msbuild_project_tools;
 pub mod nuget;
 pub mod omnisharp;
 pub mod roslyn;
 pub mod util;
 
 pub use csharp_ls::*;
+pub use msbuild_project_tools::*;
 pub use omnisharp::*;
 pub use roslyn::*;

--- a/src/language_servers/msbuild_project_tools.rs
+++ b/src/language_servers/msbuild_project_tools.rs
@@ -1,0 +1,180 @@
+use std::fs;
+
+use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
+
+use crate::language_servers::util;
+
+const GITHUB_REPO: &str = "tintoy/msbuild-project-tools-server";
+const RELEASE_ASSET: &str = "language-server.zip";
+const SERVER_DLL: &str = "MSBuildProjectTools.LanguageServer.Host.dll";
+const SETTINGS_SECTION: &str = "msbuildProjectTools";
+const DOTNET_HINT: &str = "MSBuild Project Tools requires the .NET SDK on PATH. Install the .NET \
+SDK or set `lsp.msbuild-project-tools.binary.path` to a working language server binary.";
+
+pub struct MsbuildProjectTools {
+    cached_dll_path: Option<String>,
+}
+
+impl MsbuildProjectTools {
+    pub const LANGUAGE_SERVER_ID: &'static str = "msbuild-project-tools";
+
+    pub fn new() -> Self {
+        Self {
+            cached_dll_path: None,
+        }
+    }
+
+    pub fn language_server_cmd(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let binary_settings = LspSettings::for_worktree(Self::LANGUAGE_SERVER_ID, worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+        let binary_args = binary_settings.as_ref().and_then(|b| b.arguments.clone());
+
+        if let Some(path) = binary_settings.and_then(|b| b.path) {
+            return Ok(zed::Command {
+                command: path,
+                args: binary_args.unwrap_or_default(),
+                env: Self::env(worktree),
+            });
+        }
+
+        if let Some(ref dll_path) = self.cached_dll_path {
+            if fs::metadata(dll_path).is_ok_and(|s| s.is_file()) {
+                return Self::dotnet_exec(worktree, dll_path, binary_args);
+            }
+        }
+
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+
+        let release = zed::latest_github_release(
+            GITHUB_REPO,
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == RELEASE_ASSET)
+            .ok_or_else(|| format!("no asset found matching {RELEASE_ASSET:?}"))?;
+
+        let version_dir = format!("{}-{}", Self::LANGUAGE_SERVER_ID, release.version);
+        let dll_path = format!("{version_dir}/{SERVER_DLL}");
+
+        if !fs::metadata(&dll_path).is_ok_and(|s| s.is_file()) {
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            zed::download_file(
+                &asset.download_url,
+                &version_dir,
+                zed::DownloadedFileType::Zip,
+            )
+            .map_err(|e| format!("failed to download file: {e}"))?;
+
+            util::remove_outdated_versions(Self::LANGUAGE_SERVER_ID, &version_dir)?;
+
+            if !fs::metadata(&dll_path).is_ok_and(|s| s.is_file()) {
+                return Err(format!(
+                    "msbuild-project-tools package layout unexpected: missing entry DLL at '{dll_path}'"
+                ));
+            }
+        }
+
+        let dll_path = util::absolute_path(&dll_path)?;
+        let command = Self::dotnet_exec(worktree, &dll_path, binary_args)?;
+        self.cached_dll_path = Some(dll_path);
+        Ok(command)
+    }
+
+    fn dotnet_exec(
+        worktree: &zed::Worktree,
+        dll_path: &str,
+        user_args: Option<Vec<String>>,
+    ) -> Result<zed::Command> {
+        let dotnet = worktree
+            .which("dotnet")
+            .ok_or_else(|| DOTNET_HINT.to_string())?;
+        let mut args = vec!["exec".to_string(), dll_path.to_string()];
+        if let Some(user) = user_args {
+            args.extend(user);
+        }
+        Ok(zed::Command {
+            command: dotnet,
+            args,
+            env: Self::env(worktree),
+        })
+    }
+
+    fn env(worktree: &zed::Worktree) -> Vec<(String, String)> {
+        let mut env = vec![
+            ("DOTNET_ROLL_FORWARD".to_string(), "LatestMajor".to_string()),
+            (
+                "DOTNET_ROLL_FORWARD_TO_PRERELEASE".to_string(),
+                "1".to_string(),
+            ),
+        ];
+
+        let Some(settings) = Self::user_settings(worktree) else {
+            return env;
+        };
+        let logging = &settings["logging"];
+
+        if logging["level"] == "Verbose" {
+            env.push((
+                "MSBUILD_PROJECT_TOOLS_VERBOSE_LOGGING".to_string(),
+                "1".to_string(),
+            ));
+        }
+        if let Some(log_file) = logging["file"].as_str() {
+            env.push((
+                "MSBUILD_PROJECT_TOOLS_LOG_FILE".to_string(),
+                log_file.to_string(),
+            ));
+        }
+        if let Some(seq_url) = logging["seq"]["url"].as_str() {
+            env.push((
+                "MSBUILD_PROJECT_TOOLS_SEQ_URL".to_string(),
+                seq_url.to_string(),
+            ));
+
+            if let Some(api_key) = logging["seq"]["apiKey"].as_str() {
+                env.push((
+                    "MSBUILD_PROJECT_TOOLS_SEQ_API_KEY".to_string(),
+                    api_key.to_string(),
+                ));
+            }
+        }
+
+        env
+    }
+
+    fn user_settings(worktree: &zed::Worktree) -> Option<zed::serde_json::Value> {
+        LspSettings::for_worktree(Self::LANGUAGE_SERVER_ID, worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings)
+    }
+
+    pub fn initialization_options(
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        Self::configuration_options(worktree)
+    }
+
+    pub fn configuration_options(
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        Ok(Self::user_settings(worktree).map(|s| zed::serde_json::json!({ SETTINGS_SECTION: s })))
+    }
+}


### PR DESCRIPTION
This PR adds [tintoy/msbuild-project-tools-server](https://github.com/tintoy/msbuild-project-tools-server) as a language server.

It provides completion for `PackageReference` packages and versions, properties, items, tasks, etc., as well as hover docs, go to definition and document symbols for `.csproj`, `.props`, `.targets` and `.slnx` files.

<img width="1488" height="680" alt="image" src="https://github.com/user-attachments/assets/439264a8-4696-4454-a45c-7a90609b924a" />

Currently, it downloads the latest LSP binaries directly from GitHub. Like csharp-ls, it requires dotnet to be installed in order to run. So far, I have only tested this on Windows.