### PR TITLE
Add `scoped`, `not`, `and`, `or` keyword highlights

### DIFF
--- a/languages/csharp/highlights.scm
+++ b/languages/csharp/highlights.scm
@@ -226,8 +226,10 @@
 ; pattern expression keywords
 (negated_pattern
   "not" @keyword)
+
 (and_pattern
   "and" @keyword)
+
 (or_pattern
   "or" @keyword)
 

--- a/languages/csharp/highlights.scm
+++ b/languages/csharp/highlights.scm
@@ -223,6 +223,18 @@
   "let"
 ] @keyword
 
+; pattern expression keywords
+(negated_pattern
+  "not" @keyword)
+(and_pattern
+  "and" @keyword)
+(or_pattern
+  "or" @keyword)
+
+; scoped keyword
+(scoped_type
+  "scoped" @keyword)
+
 ; Attribute
 (attribute
   name: (identifier) @attribute)


### PR DESCRIPTION
## Summary

Adds syntax highlighting for `not`, `or`, `and`, and `scoped` keywords in the C# tree-sitter highlights.

- `not` / `or` / `and`: highlight pattern keywords via `negated_pattern`, `or_pattern`, `and_pattern`
- `scoped`: highlight the `scoped` type keyword via `scoped_type`

## Before / After

<img width="786" height="769" alt="image" src="https://github.com/user-attachments/assets/a28546bc-4541-4839-bc2e-954538fc2544" />
<img width="786" height="770" alt="image" src="https://github.com/user-attachments/assets/3a4b2042-8085-4ce7-882f-63c76eee8ee0" />

## Test Plan

Opened a `.cs` file using a pattern expression and verified `not`, `or`, `and`, and `scoped` are highlighted.
